### PR TITLE
fix old python version typing

### DIFF
--- a/no_implicit_optional.py
+++ b/no_implicit_optional.py
@@ -2,6 +2,7 @@ import argparse
 import os
 import re
 import sys
+from typing import Tuple
 
 import libcst as cst
 from libcst.codemod import (
@@ -99,7 +100,7 @@ def is_typing_annotated(expr: cst.BaseExpression) -> bool:
 
 def type_hint_explicitly_allows_none_with_expr(
     expr: cst.BaseExpression,
-) -> tuple[bool, cst.BaseExpression]:
+) -> Tuple[bool, cst.BaseExpression]:
     if is_typing_annotated(expr):
         assert isinstance(expr, cst.Subscript)
         assert isinstance(expr.slice[0].slice, cst.Index)


### PR DESCRIPTION
```text
Traceback (most recent call last):
  File "...\python38\3.8.10\lib\runpy.py", line 194, in _run_module_as_main
    return _run_code(code, main_globals, None,
    exec(code, run_globals)
  File "...\Scripts\no_implicit_optional.exe\__main__.py", line 4, in <module>
  File "...\site-packages\no_implicit_optional.py", line 102, in <module>
    ) -> tuple[bool, cst.BaseExpression]:
TypeError: 'type' object is not subscriptable
```