### PR TITLE
Adding-pre-commit-hook

### DIFF
--- a/.github/workflows/sync-fork.yaml
+++ b/.github/workflows/sync-fork.yaml
@@ -1,0 +1,18 @@
+name: Sync Fork
+
+on:
+  schedule:
+    - cron: '*/30 * * * *' # every 30 minutes
+  workflow_dispatch: # on button click
+
+jobs:
+  sync:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: tgymnich/fork-sync@v1.8
+        with:
+          owner: alex-rakowski
+          base: master
+          head: master

--- a/.github/workflows/sync-fork.yaml
+++ b/.github/workflows/sync-fork.yaml
@@ -2,7 +2,7 @@ name: Sync Fork
 
 on:
   schedule:
-    - cron: '*/30 * * * *' # every 30 minutes
+    - cron: '0 0 * * 0' # every sunday at midnight
   workflow_dispatch: # on button click
 
 jobs:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 repos:
   - repo: https://github.com/alex-rakowski/no_implicit_optional
-    rev: 1.4
+    rev: 0.1.4
     hooks:
       - id: no_implicit_optional

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 repos:
-  - repo: https://github.com/alex-rakowski/no_implicit_optional/tree/pre-commits
+  - repo: https://github.com/alex-rakowski/no_implicit_optional
     rev: 1.4
     hooks:
       - id: no_implicit_optional

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 repos:
-  - repo: https://github.com/frostming/fix-future-annotations
+  - repo: https://github.com/alex-rakowski/no_implicit_optional/tree/pre-commits
     rev: 1.4
     hooks:
       - id: no_implicit_optional

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,5 @@
+repos:
+  - repo: https://github.com/frostming/fix-future-annotations
+    rev: 1.4
+    hooks:
+      - id: no_implicit_optional

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,6 @@
+-   id: no-implicit-optional
+    name: no-implicit-optional
+    description: Upgrade the typing annotations syntax to PEP 585 and PEP 604.
+    entry: no_implicit_optional
+    language: python
+    types: [python]

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,6 +1,6 @@
--   id: no_implicit_optional
-    name: no_implicit_optional
-    description: Upgrade the typing annotations syntax to PEP 585 and PEP 604.
+-   id: no_implicit_optional_checker
+    name: no implicit optional checker
+    description: remove implicit optional args.
     entry: no_implicit_optional
     language: python
     types: [python]

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,5 +1,5 @@
--   id: no-implicit-optional
-    name: no-implicit-optional
+-   id: no_implicit_optional
+    name: no_implicit_optional
     description: Upgrade the typing annotations syntax to PEP 585 and PEP 604.
     entry: no_implicit_optional
     language: python

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="no_implicit_optional",
-    version="1.4",
+    version="0.1.4",
     author="Shantanu Jain",
     author_email="hauntsaninja@gmail.com",
     description="A codemod to make your implicit optional type hints PEP 484 compliant.",


### PR DESCRIPTION
This PR adds a pre-commit-hook to the repo, addressing the issue #16. 

For this to work, a tagged release of 0.1.4 is required. 